### PR TITLE
refactor for proper error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ license = "Apache-2.0"
 [dependencies]
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
+failure = "0.1"
+failure_derive = "0.1"
 futures = "0.1"
 crossbeam = "0.7"
 rdkafka = "0.19"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Fail)]
+pub enum DashPipeError{
+    #[fail(display = "InitializeError: {}", _0)]
+    InitializeError(String),
+}

--- a/src/kafka/kafka_input.rs
+++ b/src/kafka/kafka_input.rs
@@ -7,6 +7,7 @@ use futures::future::Future;
 use futures::Stream;
 use futures::sync::mpsc::channel;
 use futures::sink::Sink;
+use rdkafka::error::KafkaError;
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::consumer::Consumer;
@@ -14,6 +15,7 @@ use rdkafka::Message;
 use log::{warn, info};
 
 use crate::InputChannel;
+use crate::error::DashPipeError;
 
 #[derive(Debug, Deserialize)]
 pub struct KafkaInput{
@@ -31,16 +33,22 @@ impl KafkaInput{
 }
 
 impl InputChannel for KafkaInput{
-    fn start(&self) -> Box<Stream<Item=String, Error = io::Error>>{
-        Box::new(receive_messages(&self.config, &self.topics))
+    fn start(&self) -> Result<Box<Stream<Item=String, Error = io::Error>>, DashPipeError>{
+        let sconsumer = match build_streaming_consumer(&self.config){
+            Ok(c) => c,
+            Err(e) => return Err(DashPipeError::InitializeError("Unable to initialize Kakfa".to_string())),
+        };
+
+        match sconsumer.subscribe(&[&self.topics]){
+            Ok(_) => {},
+            Err(e) => return Err(DashPipeError::InitializeError("Unable to initialize Kakfa".to_string())),
+        }
+
+        Ok(Box::new(receive_messages_fn(sconsumer)))
     }
 }
 
-fn receive_messages(config: &HashMap<String, String>, topics: &str) -> impl Stream<Item=String, Error=io::Error>{
-    let sconsumer = build_streaming_consumer(config);
-
-    sconsumer.subscribe(&[topics]).expect("Can't subscribe to specified topic");
-
+fn receive_messages_fn(sconsumer: StreamConsumer) -> impl Stream<Item=String, Error=io::Error> {
     let (mut sender, receiver) = channel(1000);
     thread::spawn(move || {
         let message_stream = sconsumer.start();
@@ -66,15 +74,11 @@ fn receive_messages(config: &HashMap<String, String>, topics: &str) -> impl Stre
     receiver.then(|result|{result.unwrap()})
 }
 
-fn build_streaming_consumer(kafkaconfig: &HashMap<String, String>) -> StreamConsumer{
+
+fn build_streaming_consumer(kafkaconfig: &HashMap<String, String>) -> Result<StreamConsumer, KafkaError> {
     let mut client_config = ClientConfig::new();
     for (key, value) in kafkaconfig{
         client_config.set(&key, &value);
     }
-
-    let consumer: StreamConsumer = match client_config.create() {
-        Ok(c) => c,
-        Err(e) => panic!("Unnable to intiialize kafka, {}", e),
-    };
-    consumer
+   client_config.create()
 }

--- a/src/kafka/kafka_output.rs
+++ b/src/kafka/kafka_output.rs
@@ -1,5 +1,7 @@
 use crate::OutputChannel;
+use crate::error::DashPipeError;
 
+use log::{error, info};
 use std::collections::HashMap;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::config::ClientConfig;
@@ -10,36 +12,41 @@ pub struct KafkaOutput{
 }
 
 impl KafkaOutput{
-    pub fn new(kafka_config: HashMap<String, String>, a_topic: String) -> KafkaOutput{
-        let a_producer = build_producer(&kafka_config);
-        KafkaOutput{
-            topic: a_topic,
-            producer : a_producer,
+    pub fn new(kafka_config: HashMap<String, String>, a_topic: String) -> Result<KafkaOutput, DashPipeError>{
+        match build_producer(&kafka_config){
+            Ok(producer) => Ok(KafkaOutput{
+                                topic: a_topic,
+                                producer : producer,
+                              }),
+            Err(e) => Err(e),
         }
     }
 }
 
 impl OutputChannel for KafkaOutput{
     fn send(&self, msg: String){
+        //TODO how can we customize the key??
         let record = FutureRecord::to(&self.topic)
                     .payload(&msg)
                     .key(&msg);
         //TODO add a handle here and_then or a map to keep metrics on success and
         //failure
         self.producer.send(record, 100);
-        println!("sent data");
     }
 }
 
-fn build_producer(kafkaconfig: &HashMap<String, String>) -> FutureProducer{
+fn build_producer(kafkaconfig: &HashMap<String, String>) -> Result<FutureProducer, DashPipeError>{
     let mut client_config = ClientConfig::new();
     for (key, value) in kafkaconfig{
         client_config.set(&key, &value);
     }
 
-    let producer: FutureProducer = match client_config.create(){
-        Ok(c) => {println!("Properly created producer"); c},
-        Err(e) => panic!("Unnable to intiialize kafka, {}", e),
-    };
-    producer
+    match client_config.create(){
+        Ok(c) => {info!("Properly created producer"); Ok(c)},
+        Err(e) => {
+            let disp = format!("Unable to initialize kakfa producer {}", e);
+            error!("Unnable to intiialize kafka, {}", e);
+            Err(DashPipeError::InitializeError(disp))
+        },
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,20 +3,25 @@ extern crate log;
 extern crate nitox;
 #[macro_use]
 extern crate lazy_static;
+extern crate failure;
+#[macro_use]
+extern crate failure_derive;
 
 use futures::Stream;
 use std::io;
- 
+
+mod error; 
 mod standard;
 mod kafka;
 mod nats;
 
+pub use self::error::*;
 pub use standard::{StdinInput, StdoutOutput};
 pub use kafka::{KafkaInput, KafkaOutput};
 pub use nats::{NatsOutput, NatsInput};
 
 pub trait InputChannel{
-    fn start(&self) -> Box<Stream<Item=String, Error = io::Error>>;
+    fn start(&self) -> Result<Box<Stream<Item=String, Error = io::Error>>, DashPipeError>;
 }
 
 pub trait OutputChannel{

--- a/src/standard/stdin_input.rs
+++ b/src/standard/stdin_input.rs
@@ -5,6 +5,7 @@ use futures::{Stream, Sink, Future};
 use futures::sync::mpsc::channel;
 
 use crate::InputChannel;
+use crate::error::DashPipeError;
 
 pub struct StdinInput{
 
@@ -17,8 +18,8 @@ impl StdinInput{
 }
 
 impl InputChannel for StdinInput{
-    fn start(&self) -> Box<Stream<Item=String, Error = io::Error>>{
-        Box::new(stdin())
+    fn start(&self) -> Result<Box<Stream<Item=String, Error = io::Error>>, DashPipeError>{
+        Ok(Box::new(stdin()))
     }
 }
 

--- a/tests/nats_integration.rs
+++ b/tests/nats_integration.rs
@@ -64,7 +64,7 @@ fn test_receive_messages(){
     let node = docker.run(nats_image);
     let cluster_uri = format!("localhost:{}", node.get_host_port(4222).unwrap());
 
-    let input = NatsInput::new(&cluster_uri, "receivedata".to_string(), None).expect("Unable to start NATS");
+    let input : NatsInput = NatsInput::new(&cluster_uri, "receivedata".to_string(), None).expect("Unable to start NATS");
 
     let connect_cmd = ConnectCommand::builder().build().unwrap();
     let options = NatsClientOptions::builder()
@@ -88,7 +88,7 @@ fn test_receive_messages(){
     runtime.spawn(fut.or_else(|_|{Ok(())}));
 
     let mut messages: Vec<String> = Vec::new();
-    let _ = input.start()
+    let _ = input.start().expect("Unable to start stream")
        .take(5)
        .for_each(|m| { 
            let _ = messages.push(m); 

--- a/tests/nats_integration.rs
+++ b/tests/nats_integration.rs
@@ -19,7 +19,7 @@ fn test_send_message(){
                     .with_wait_for(WaitFor::message_on_stderr("Listening for client connections"));
     let node = docker.run(nats_image);
     let cluster_uri = format!("localhost:{}", node.get_host_port(4222).unwrap());
-    let output = NatsOutput::new(&cluster_uri, "testsubject".to_string());
+    let output = NatsOutput::new(&cluster_uri, "testsubject".to_string()).expect("Unable to initialize NATS");
 
     let connect_cmd = ConnectCommand::builder().build().unwrap();
     let options = NatsClientOptions::builder()
@@ -64,7 +64,7 @@ fn test_receive_messages(){
     let node = docker.run(nats_image);
     let cluster_uri = format!("localhost:{}", node.get_host_port(4222).unwrap());
 
-    let input = NatsInput::new(&cluster_uri, "receivedata".to_string(), None);
+    let input = NatsInput::new(&cluster_uri, "receivedata".to_string(), None).expect("Unable to start NATS");
 
     let connect_cmd = ConnectCommand::builder().build().unwrap();
     let options = NatsClientOptions::builder()


### PR DESCRIPTION
Fixes #9 
# dashpipe core PR
Fixes traits and error handling to avoid using panics from a library 

### Added
* error type

### Changed
* input and output trait to return a result with error and object instead of panic
